### PR TITLE
Add migration to make user id type bigint.

### DIFF
--- a/src/migrations/1701778887351-id-to-bigint.ts
+++ b/src/migrations/1701778887351-id-to-bigint.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class IdToBigint1701778887351 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('ALTER TABLE "user" ALTER COLUMN "id" TYPE bigint');
+        await queryRunner.query('ALTER TABLE "purchase" ALTER COLUMN "userId" TYPE bigint');
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('ALTER TABLE "user" ALTER COLUMN "id" TYPE integer');
+        await queryRunner.query('ALTER TABLE "purchase" ALTER COLUMN "userId" TYPE integer');
+    }
+
+}


### PR DESCRIPTION
I found my user id is bigint. So I got out of range error requesting `/purchases` endpoint.